### PR TITLE
Limit previous and next button functionality

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -28,14 +28,16 @@ define(['js/properties', 'js/sound'], function(properties, sound) {
 
     const previousLevel = function(event) {
         if (level.number === 1) {
-            document.getElementById("previous").diabled = true;
+            document.getElementById("previous").disabled = true;
         } else {
             level = loadLevel(level.number-1);
         }
     };
 
     const nextLevel = function(event) {
-        if(level.number <= properties.NUMBER_OF_LEVELS) {
+        if(level.number === properties.NUMBER_OF_LEVELS) {
+            document.getElementById("next").disabled = true;
+        } else {
             level = loadLevel(level.number+1);
         }
     };

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -27,7 +27,9 @@ define(['js/properties', 'js/sound'], function(properties, sound) {
     };
 
     const previousLevel = function(event) {
-        if(level.number >= 1) {
+        if (level.number === 1) {
+            document.getElementById("previous").diabled = true;
+        } else {
             level = loadLevel(level.number-1);
         }
     };
@@ -52,8 +54,8 @@ define(['js/properties', 'js/sound'], function(properties, sound) {
                 button.width = 53;
                 button.height = 53;
                 button.src = properties.BUTTONS_IMAGES_FOLDER+id+properties.BUTTONS_IMAGES_EXTENSION;
-                button.title = description;    
-                return button;        
+                button.title = description;
+                return button;
             }
 
             var buttonsElement = document.createElement("div");


### PR DESCRIPTION
This PR:
- prevents the previous level button from working when the player is on the first level.
- prevents the next level button from working when the player is on the last level.

This is done by setting the button's `disabled` property to `true` if the condition is met.

This closes #7.