### PR TITLE
Improve UX that will not allow Desktop user to drag and select the image

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -90,6 +90,7 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], function(pro
                 squareImageElement.className = "squareImage unpinned";
                 squareImageElement.id = square.generateImageId();
                 squareImageElement.src = squareImages.generateImagePath(square.currentImage);
+                squareImageElement.draggable = false;
                 return squareImageElement;
             }
 

--- a/styles.css
+++ b/styles.css
@@ -104,13 +104,23 @@ div.square.pin {
 img.squareImage.unpinned {
     border: solid transparent;
     border-radius: 0px;
-    border-width: 2px;
+    border-width: 2px;  
+    /* make user select unavailable */
+    -webkit-user-select: none;  
+    -moz-user-select: none;     
+    -ms-user-select: none;     
+    user-select: none;     
 }
 
 img.squareImage.pinned {
     border: groove #cc0000;
     border-radius: 13px;
     border-width: 2px;
+    -webkit-user-select: none; 
+    -moz-user-select: none;   
+    -ms-user-select: none;    
+    user-select: none;          
+
 }
 
 .game-description {


### PR DESCRIPTION
UX added:
- Desktop user will not able top drag the image (works on chrome)
- User will not able to select the squareImage (tested on chrome and firefox)
Tested on Google Chrome.