### PR TITLE
Updating infoTest.js file and adding squareImagesTest.js file

### DIFF
--- a/test/entryFileTest.js
+++ b/test/entryFileTest.js
@@ -1,3 +1,4 @@
 require('babel-register'); 
 require('./levelsTest.js'); 
 require('./infoTest.js'); 
+require('./squareImagesTest.js');

--- a/test/infoTest.js
+++ b/test/infoTest.js
@@ -4,6 +4,41 @@ const requirejs = require("requirejs");
 test("info.js tests", (assert) => {
     requirejs(["./require-config.js", "./js/info.js"], function(config, info) {
         assert.notEqual(null, info);
+
+        // generateInfo
+        assert.ok(info.hasOwnProperty("generateInfo"), 
+            "Asserts that info.js has a property called generateInfo");
+        assert.equal(typeof info.generateInfo, "function",
+            "Asserts that the value type of 'generateInfo' property is a function");
+
+        // addMovement
+        assert.ok(info.hasOwnProperty("addMovement"), 
+            "Asserts that info.js has a property called addMovement");
+        assert.equal(typeof info.addMovement, "function",
+            "Asserts that the value type of 'addMovement' property is a function");
+
+        // stop
+        assert.ok(info.hasOwnProperty("stop"), 
+            "Asserts that info.js has a property called stop");
+        assert.equal(typeof info.stop, "function",
+            "Asserts that the value type of 'stop' property is a function");
+
+        // medalTime
+        assert.ok(info.hasOwnProperty("medalTime"), 
+            "Asserts that info.js has a property called medalTime");
+        assert.equal(typeof info.medalTime, "function",
+            "Asserts that the value type of 'medalTime' property is a function");
+        assert.equal(typeof info.medalTime(), "number", 
+            "Asserts that 'medalTime()' function returns a value with number type");
+
+        // movementTotal
+        assert.ok(info.hasOwnProperty("movementTotal"), 
+            "Asserts that info.js has a property called movementTotal");
+        assert.equal(typeof info.movementTotal, "function",
+            "Asserts that the value type of 'movementTotal' property is a function");
+        assert.equal(typeof info.movementTotal(), "number", 
+            "Asserts that 'movementTotal()' function returns a value with number type");
+
         assert.end();
     });
 });

--- a/test/squareImagesTest.js
+++ b/test/squareImagesTest.js
@@ -1,0 +1,42 @@
+import test from "tape";
+const requirejs = require("requirejs");
+
+test("squareImages.js tests", (assert) => {
+    requirejs(["./require-config.js", "./js/squareImages.js"], function(config, square) {
+        assert.notEqual(null, square);
+
+        // imageValuesEquivalent
+        assert.ok(square.hasOwnProperty("imageValuesEquivalent"), 
+            "Asserts that squareImages.js has a property called imageValuesEquivalent");
+        assert.equal(typeof square.imageValuesEquivalent, "function", 
+            "Asserts that the value type of property 'imageValuesEquivalent' is a function");
+        assert.equal(typeof square.imageValuesEquivalent(), "boolean",
+            "Asserts that 'imageValuesEquivalent()' function returns a value with boolean type");
+
+        // generateImagePath
+        assert.ok(square.hasOwnProperty("generateImagePath"),
+            "Asserts that squareImages.js has a property called generateImagePath");
+        assert.equal(typeof square.generateImagePath, "function", 
+            "Asserts that the value type of property 'generateImagePath' is a function");
+
+        // getPosition
+        assert.ok(square.hasOwnProperty("getPosition"),
+            "Asserts that squareImages.js has a property called getPosition");
+        assert.equal(typeof square.getPosition, "function", 
+            "Asserts that the value type of property 'getPosition' is a function");
+
+        // nextImage
+        assert.ok(square.hasOwnProperty("nextImage"), 
+            "Asserts that squareImages.js has a property called nextImage");
+        assert.equal(typeof square.nextImage, "function", 
+            "Asserts that the value type of property 'nextImage' is a function");
+
+        // pinnableImage
+        assert.ok(square.hasOwnProperty("pinnableImage"),
+            "Asserts that squareImages.js has a property called pinnableImage");
+        assert.equal(typeof square.pinnableImage, "function", 
+            "Asserts that the value type of property 'pinnableImage' is a function");
+
+        assert.end();
+    });
+});


### PR DESCRIPTION
Adding some tests and their descriptions to infoTest.js and squareImagesTest.js file to the project.

The descriptions of the tests can pollute the code a little, but it increases visibility when the test is executed, making it easier to identify which test has failed.

**Obs.:** when I tried to execute the existing test cases using item **5** described on this project's **README¹**, a SyntaxError² was thrown. 
> ¹ 5. run a test example: node -r ./test/entryFileTest.js
>² `SyntaxError: Unexpected token import`


This is not exactly an error. What happened is that I misread the README instruction and thought that `node -r` could execute each test file individually instead of all the test cases.

To run each test case individually, I used the command `npx babel-node <testName.js>`, that was found [here](https://medium.com/@JedaiSaboteur/import-export-babel-and-node-a2e332d15673).